### PR TITLE
fix: backup "location" parameter

### DIFF
--- a/launcher/api.go
+++ b/launcher/api.go
@@ -25,10 +25,12 @@ func ConfigureRouter(r *gin.Engine) {
 			err := c.BindJSON(&settings)
 			if err != nil {
 				utils.JsonError(c, err.Error(), http.StatusBadRequest)
+				return
 			}
 			ok, err := UpdateBackup(settings)
 			if ok {
 				c.Status(http.StatusNoContent)
+				return
 			}
 			if err != nil {
 				utils.JsonError(c, err.Error(), http.StatusBadRequest)

--- a/launcher/ws.go
+++ b/launcher/ws.go
@@ -126,7 +126,7 @@ func (t *Launcher) GetInfo() (*json.RawMessage, error){
 }
 
 type BackupSettings struct {
-	Location string
+	Location string `json:"location"`
 }
 
 func UpdateBackup(settings BackupSettings) (bool, error) {


### PR DESCRIPTION
The `/api/v1/backup` payload will change from `{"Location": "..."}` to `{"location": "..."}`